### PR TITLE
Add `types` field in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
![image](https://github.com/enkot/set-cookie-parser-es/assets/10386119/7970bd33-4867-4b3f-b4a9-2a99e3d6a995)

The `import` path as defined in the `exports` field is `.mjs`, so typescript will look for `.d.mts` as the resolved type definitions if `types` field is not defined, which doesn't exist. We can explicitly set the `types` path in the `exports` field to prevent this issue. 

Also sharing a same `.d.ts` file may cause problems for a dual module package (cjs + esm), however this package doesn't suffer from these problems.